### PR TITLE
fix #4, not change presenter when user posted with false as register-me.

### DIFF
--- a/app/controllers/member/page/EventPage.scala
+++ b/app/controllers/member/page/EventPage.scala
@@ -158,7 +158,7 @@ object EventPage extends AuthenticateUtil {
         val newEventInfo = if (formEventInfo.registerMe) {
           formEventInfo.copy(authorIdOrNone = userInfo.id).toEventInfo
         } else {
-          formEventInfo.copy(authorIdOrNone = None).toEventInfo
+          formEventInfo.toEventInfo
         }
         val successMessage = newEventInfo.id match {
           case Some(eventInfoId) =>


### PR DESCRIPTION
registerMeをfalseで送信した場合に、発表者を消していた処理を修正。
